### PR TITLE
added test-user with profiles

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
       - ./volumes/dancer-data:/var/lib/postgresql/data
 
   pg-admin:
-    image: dpage/pgadmin4:latest
+    image: dpage/pgadmin4:6.15
     restart: always
     ports:
       - "5050:80"

--- a/src/test/java/net/dancier/dancer/core/EndToEndProfileTest.java
+++ b/src/test/java/net/dancier/dancer/core/EndToEndProfileTest.java
@@ -43,7 +43,7 @@ public class EndToEndProfileTest extends AbstractPostgreSQLEnabledTest {
     }
 
     @Test
-    @WithUserDetails("user@dancier.net")
+    @WithUserDetails("user-without-profile@dancier.net")
     void fromVirginProfileToPopulatedProfile() throws Exception {
         ResultActions initialGetOfProfile = mockMvc.perform(get("/profile"));
         initialGetOfProfile.andExpect(status().isOk())

--- a/src/test/java/net/dancier/dancer/recommendation/EndToEndRecommendationTest.java
+++ b/src/test/java/net/dancier/dancer/recommendation/EndToEndRecommendationTest.java
@@ -4,15 +4,12 @@ import net.dancier.dancer.AbstractPostgreSQLEnabledTest;
 import net.dancier.dancer.authentication.model.User;
 import net.dancier.dancer.authentication.repository.UserRepository;
 import net.dancier.dancer.core.DancerRepository;
-import net.dancier.dancer.core.model.Dancer;
-import net.dancier.dancer.security.JwtTokenProvider;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.security.test.context.support.WithUserDetails;
 import org.springframework.test.web.servlet.ResultActions;
-
-import javax.servlet.http.Cookie;
-import java.util.UUID;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -20,35 +17,13 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 public class EndToEndRecommendationTest extends AbstractPostgreSQLEnabledTest {
 
-    @Autowired
-    DancerRepository dancerRepository;
-
-    @Autowired
-    UserRepository userRepository;
-
-    @Autowired
-    JwtTokenProvider jwtTokenProvider;
-
-    User user = null;
-    @BeforeEach
-    public void init() {
-        user = userRepository.findByEmail("user@dancier.net").get();
-        Dancer dancer = new Dancer();
-        dancer.setUserId(user.getId());
-        dancer.setDancerName("dancero");
-        dancer.setCity("Dortmund");
-        dancerRepository.save(dancer);
-    }
-
     @Test
+    @WithUserDetails("user-with-a-profile@dancier.net")
     public void getRecommendation() throws Exception {
-        ResultActions resultActions = mockMvc.perform(get("/recommendations").cookie(getUserCookie(user.getId())));
+        ResultActions resultActions =
+                mockMvc.perform(get("/recommendations"));
         resultActions.andExpect(status().isOk());
         resultActions.andExpect(jsonPath("$").isArray());
-    }
-
-    private Cookie getUserCookie(UUID userId) {
-        return new Cookie("jwt-token", jwtTokenProvider.generateJwtToken(userId.toString()));
     }
 
 }

--- a/src/test/resources/data.sql
+++ b/src/test/resources/data.sql
@@ -1,9 +1,17 @@
--- one ordinary user
+-- We are configuring three users here
+-- user-without-profile@dancier.net
+--   -> valid user without a profile, roles ROLE_USER, ROLE_HUMAN
+-- user-without-a-profile@dancier.net
+--   -> valid user with a profile (just the id), roles ROLE_USER, ROLE_HUMAN
+-- admin@dancier.net
+--   -> valid user with admin rights without a profile
+
+-- one ordinary user without a profile
 INSERT
   INTO users (id, email, password, email_validated )
   VALUES (
     '62ff5258-8976-11ec-b58c-e35f5b1fc926',
-    'user@dancier.net',
+    'user-without-profile@dancier.net',
     '$2a$10$GOChyBEqco9m3wZwkh0RqOTwyWq4HmocguPPfEraSgnbmlrM4.Fey',
      true
   );
@@ -13,9 +21,31 @@ INSERT
 SELECT '62ff5258-8976-11ec-b58c-e35f5b1fc926',
        id
   FROM roles
- WHERE name = 'ROLE_USER';
+ WHERE name IN ('ROLE_USER', 'ROLE_HUMAN');
+
+-- one ordinary user with a profile
+INSERT
+  INTO users (id, email, password, email_validated )
+  VALUES (
+    '55bbf334-6649-11ed-8f65-5b299f0e161f',
+    'user-with-a-profile@dancier.net',
+    '$2a$10$GOChyBEqco9m3wZwkh0RqOTwyWq4HmocguPPfEraSgnbmlrM4.Fey',
+     true
+  );
+
+INSERT
+  INTO user_roles (user_id, role_id)
+SELECT '55bbf334-6649-11ed-8f65-5b299f0e161f',
+       id
+  FROM roles
+ WHERE name IN ('ROLE_USER', 'ROLE_HUMAN');
+
+INSERT
+  INTO dancer(user_id, id)
+VALUES ('55bbf334-6649-11ed-8f65-5b299f0e161f', '11065e54-664a-11ed-872e-1b1eb88b44b6');
 
 -- one admin
+-- no profile attached
 INSERT
   INTO users (id, email, password, email_validated )
   VALUES (
@@ -30,4 +60,4 @@ INSERT
 SELECT '21df1a30-89a6-11ec-b4cf-67ea17ff4219',
        id
   FROM roles
- WHERE name = 'ROLE_USER';
+ WHERE name IN ('ROLE_USER', 'ROLE_ADMIN', 'ROLE_HUMAN');


### PR DESCRIPTION
Why have I done this:

Whenever we need a Mocked User that also has a profile we could not have used the convenient Annotation @WithUserDetails.

This does not work because the Annotation is being processed before an @BeforeEach Annotation is being processed.
In this BeforeEach Annotation we would have set a profile for the user.
But as the Profile would be set _after_ the @WithUserDetails has been processed, the former one would have created a Princicap without a dancer_id.
Then code would fail.
For this reason we have additionally created artificially cookies with jwts, and handed them into the test-requests.
This is just repeated work.

With this pr, I just setup one additional test-user, that will be inserted into the database before each tests run.
This one will have a dancer_id.
So:
not need to 
- always create a profile
- create a cookie
- hand in a cookie